### PR TITLE
IssueID #20539 - Updated the Curation tasks config template file cura…

### DIFF
--- a/templates/curate.cfg.erb
+++ b/templates/curate.cfg.erb
@@ -12,7 +12,9 @@ plugin.named.org.dspace.curate.CurationTask = \
     org.dspace.ctask.general.RequiredMetadata = requiredmetadata, \
     org.dspace.ctask.general.ClamScan = vscan, \
     org.dspace.ctask.general.MicrosoftTranslator = translate, \
-    org.dspace.ctask.general.MetadataValueLinkChecker = checklinks
+    org.dspace.ctask.general.MetadataValueLinkChecker = checklinks, \
+    uk.ac.edina.datashare.ctask.general.EmailableBitstreamsChecker = emailablebitstreams
+
 # add new tasks here
 
 ## task queue implementation

--- a/templates/dspace.cfg.erb
+++ b/templates/dspace.cfg.erb
@@ -2132,4 +2132,7 @@ datasets.path = <%= @ds_datasets_dir %>
 
 apache.log.dir = <%= @ap_log_dir %>
 
+# Max bitstreams size (in MB) emailable
+emailable.bitstreams.max.size = 100
+
 #####################################################################


### PR DESCRIPTION
…te.cfg.erb:

- with new curation task emailablebitstreams
- added a property "emailable.bitstreams.max.size" to dspace.cfg.erb which has been set to 100MB.
Otherwise the "Document copy request" page hangs on clicking the "submit" button for
files above 100 MB.